### PR TITLE
Discord Notification Preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # minecraft-discord-webhook
+
 A small, server agnostic, way to push your Minecraft server updates to Discord
 
 ![image](https://user-images.githubusercontent.com/23201434/120118752-7e06c880-c16a-11eb-84fb-cce9fb123b38.png)
 
 This script will push your easily push:
+
 - Server joins and leaves
 - Deaths
 - Advancements, challenges and goals
@@ -14,15 +16,17 @@ This script works by reading your server log file, parsing and formatting it usi
 
 ## Usage
 
-### With Docker:
+### With Docker
 
 There's an image avaible on [Docker Hub](https://hub.docker.com/r/saadbruno/minecraft-discord-webhook)!
 
-#### Docker run:
+#### Docker run
+
 `docker run --name minecraft-discord-webhook -v /path/to/server/logs:/app/logs:ro --env WEBHOOK_URL=https://discord.com/api/webhooks/111222333/aaabbbccc --env FOOTER=Optional\ Footer\ Text --env LANGUAGE=en-US saadbruno/minecraft-discord-webhook:latest`
 > Note: FOOTER and LANGUAGE are optional
 
-#### Docker Compose:
+#### Docker Compose
+
 ```
 version: '3.3'
 services:
@@ -37,13 +41,15 @@ services:
         image: 'saadbruno/minecraft-discord-webhook:latest'
         restart: unless-stopped
 ```
+
 > Note: FOOTER and LANGUAGE are optional
 
-### Without Docker:
+### Without Docker
+
 - Clone the repo
 - run `WEBHOOK_URL=<discord webhook> SERVERLOG=</path/to/server/logs> FOOTER=<optional footer> LANGUAGE=<optional language> ./minecraft-discord.webook.sh`
 
-## Variables:
+## Variables
 
 - WEBHOOK_URL: it's the discord webhook you want the notifications posted to. Read more at [Discord Support](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks)
 - LANGUAGE: The language of the notifications. This only supports joins and leaves. Advancements and death messages are posted "as is", meaning they'll be posted using the language of your server. Check the [lang directory](https://github.com/saadbruno/minecraft-discord-webhook/tree/main/lang) for currently supported languages. Contributions are welcome!
@@ -51,4 +57,5 @@ services:
  ![image](https://user-images.githubusercontent.com/23201434/120119109-44cf5800-c16c-11eb-9ce1-8927629c805f.png)
 
 ## Notes on logs
+
 You have to pass the **entire logs diretory path** to the script, rather than just the `latest.log`. This is due to how Docker volumes work. If we're mounting just the `latest.log` file, when the Minecraft server rotates that log, Docker will not mount the new file automatically.

--- a/minecraft-discord-webhook.sh
+++ b/minecraft-discord-webhook.sh
@@ -24,7 +24,7 @@ fi
 
 DIR=$(dirname $0)
 
-# cache forces minotar to guve us a new avatar every day, in case players change their skins
+# cache forces minotar to give us a new avatar every day, in case players change their skins
 CACHE=$(date +'%Y%m%d')
 
 # Let's default our language to english
@@ -48,6 +48,7 @@ function webhook_compact() {
         -d '{
                 "username": "Minecraft",
                 "avatar_url" : "https://www.minecraft.net/etc.clientlibs/minecraft/clientlibs/main/resources/android-icon-192x192.png",
+                "content": "'"$1"'",
                 "embeds": [{
                     "color": "'"$2"'",
                     "author": {
@@ -57,8 +58,8 @@ function webhook_compact() {
                     "footer": {
                         "text": "'"$FOOTER"'"
                     }
-                }
-            ]}' $WEBHOOK_URL
+                }]
+            }' $WEBHOOK_URL
 }
 
 # actual loop with parsing of the log


### PR DESCRIPTION
# Pull Request

The embedded Discord notification does not show previews in notifications on mobile Discord, meaning you have to open the app to view the notification contents. I've added a content field to allow people to read the information in mobile notification previews. 

I've also added some spelling fixes and markdown syntax fixes.

I opened a pull request to hope that this could be rebuilt into your container... mainly because I don't want to publish my own container and switch images. I could also figure out how to just publish my own docker containers but fingers crossed you'll accept these changes.