### PR TITLE
Add parsing of GeyserMC-logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ services:
 - LANGUAGE: The language of the notifications. This only supports joins and leaves. Advancements and death messages are posted "as is", meaning they'll be posted using the language of your server. Check the [lang directory](https://github.com/saadbruno/minecraft-discord-webhook/tree/main/lang) for currently supported languages. Contributions are welcome!
 - FOOTER: An optional footer text that will be included with the notifications, you can put your server name, server address or anything else. You can also ommit this for a more compact notification.
  ![image](https://user-images.githubusercontent.com/23201434/120119109-44cf5800-c16c-11eb-9ce1-8927629c805f.png)
+- AVATAR: URL of an image to use as the bot-avatar.  Defaults to https://www.minecraft.net/etc.clientlibs/minecraft/clientlibs/main/resources/android-icon-192x192.png
+- BOTNAME: Name of the bot in the Discord channel. Defaults to "Minecraft"
+- PREVIEW: If set - will also add a preview of the message in the Discord channel
 
 ## Notes on logs
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ services:
 - LANGUAGE: The language of the notifications. This only supports joins and leaves. Advancements and death messages are posted "as is", meaning they'll be posted using the language of your server. Check the [lang directory](https://github.com/saadbruno/minecraft-discord-webhook/tree/main/lang) for currently supported languages. Contributions are welcome!
 - FOOTER: An optional footer text that will be included with the notifications, you can put your server name, server address or anything else. You can also ommit this for a more compact notification.
  ![image](https://user-images.githubusercontent.com/23201434/120119109-44cf5800-c16c-11eb-9ce1-8927629c805f.png)
-- AVATAR: URL of an image to use as the bot-avatar.  Defaults to ![image](https://www.minecraft.net/etc.clientlibs/minecraft/clientlibs/main/resources/android-icon-192x192.png)
+- AVATAR: URL of an image to use as the bot-avatar.  Defaults to https://www.minecraft.net/etc.clientlibs/minecraft/clientlibs/main/resources/android-icon-192x192.png
 - BOTNAME: Name of the bot in the Discord channel. Defaults to "Minecraft"
 - PREVIEW: If set - will also add a preview of the message in the Discord channel
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ services:
 - LANGUAGE: The language of the notifications. This only supports joins and leaves. Advancements and death messages are posted "as is", meaning they'll be posted using the language of your server. Check the [lang directory](https://github.com/saadbruno/minecraft-discord-webhook/tree/main/lang) for currently supported languages. Contributions are welcome!
 - FOOTER: An optional footer text that will be included with the notifications, you can put your server name, server address or anything else. You can also ommit this for a more compact notification.
  ![image](https://user-images.githubusercontent.com/23201434/120119109-44cf5800-c16c-11eb-9ce1-8927629c805f.png)
-- AVATAR: URL of an image to use as the bot-avatar.  Defaults to https://www.minecraft.net/etc.clientlibs/minecraft/clientlibs/main/resources/android-icon-192x192.png
+- AVATAR: URL of an image to use as the bot-avatar.  Defaults to ![image](https://www.minecraft.net/etc.clientlibs/minecraft/clientlibs/main/resources/android-icon-192x192.png)
 - BOTNAME: Name of the bot in the Discord channel. Defaults to "Minecraft"
 - PREVIEW: If set - will also add a preview of the message in the Discord channel
 

--- a/minecraft-discord-webhook.sh
+++ b/minecraft-discord-webhook.sh
@@ -75,7 +75,7 @@ function webhook_compact() {
 }
 
 # send a message that the service has started
-webhook_compact "$0 started monitoring $SERVERLOG/latest.log" 9737364 "https://www.minecraft.net/etc.clientlibs/minecraft/clientlibs/main/resources/android-icon-192x192.png"
+webhook_compact "$0 started monitoring $SERVERLOG/latest.log" 9737364 "$AVATAR"
 
 # actual loop with parsing of the log
 tail -n 0 -F $SERVERLOG/latest.log | while read LINE; do

--- a/minecraft-discord-webhook.sh
+++ b/minecraft-discord-webhook.sh
@@ -43,12 +43,11 @@ echo "================================================="
 
 # compact version of the webhook
 function webhook_compact() {
-    curl -H "Content-Type: application/json" \
+    curl --no-progress-meter -H "Content-Type: application/json" \
         -X POST \
         -d '{
                 "username": "Minecraft",
                 "avatar_url" : "https://www.minecraft.net/etc.clientlibs/minecraft/clientlibs/main/resources/android-icon-192x192.png",
-                "content": "'"$1"'",
                 "embeds": [{
                     "color": "'"$2"'",
                     "author": {
@@ -64,7 +63,6 @@ function webhook_compact() {
 
 # actual loop with parsing of the log
 tail -n 0 -F $SERVERLOG/latest.log | while read LINE; do
-
     case $LINE in
 
     # match for chat message. If it's chat, we catch it first so we don't trigger false positives later
@@ -101,6 +99,73 @@ tail -n 0 -F $SERVERLOG/latest.log | while read LINE; do
         source $LANGFILE
         echo "$PLAYER made an advancement! Sending webhook..."
         webhook_compact "$MESSAGE" 2842864 "https://minotar.net/helm/$PLAYER?v=$CACHE"
+        ;;
+
+    # Geyser main server messages
+    *main\/INFO\]*)
+        MESSAGE=$(echo "$LINE" | cut -d "]" -f 2 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+        source $LANGFILE
+        echo "Geyser INFO-message. Sending webhook..."
+        webhook_compact "$MESSAGE" 3447003 "https://geysermc.org/img/icons/geyser.png"
+        ;;
+
+    # Geyser main server messages
+    *main\/WARN\]*)
+        MESSAGE=$(echo "$LINE" | cut -d "]" -f 2 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+        source $LANGFILE
+        echo "Geyser WARN-message. Sending webhook..."
+        webhook_compact "$MESSAGE" 10366780 "https://geysermc.org/img/icons/geyser.png"
+        ;;
+
+    # Geyser client connect
+    *tried\ to\ connect*)
+        MESSAGE=$(echo "$LINE" | cut -d "]" -f 2 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+        source $LANGFILE
+        echo "Geyser Connect-message. Sending webhook..."
+        webhook_compact "$MESSAGE" 3447003 "https://geysermc.org/img/icons/geyser.png"
+        ;;
+
+    # Geyser client with stored cred
+    *Using\ stored\ credentials*)
+        MESSAGE=$(echo "$LINE" | cut -d "]" -f 2 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+        PLAYER=$(echo "$LINE" | rev | cut -d " " -f 1 | rev)
+        source $LANGFILE
+        echo "Geyser Cred-message. Sending webhook..."
+        webhook_compact "$MESSAGE" 3447003 "https://minotar.net/helm/$PLAYER?v=$CACHE"
+        ;;
+
+    # Geyser client successfully connected
+    *Player\ connected\ with\ username*)
+        MESSAGE=$(echo "$LINE" | cut -d "]" -f 2 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+        PLAYER=$(echo "$LINE" | rev | cut -d " " -f 1 | rev)
+        source $LANGFILE
+        echo "Geyser Player-message. Sending webhook..."
+        webhook_compact "$MESSAGE" 3447003 "https://minotar.net/helm/$PLAYER?v=$CACHE"
+        ;;
+
+    # Geyser client proxied 
+    *has\ connected\ to\ remote* | has\ disconnected\ from\ remote )
+        MESSAGE=$(echo "$LINE" | cut -d "]" -f 2 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+        PLAYER=$(echo "$MESSAGE" | cut -d " " -f 1)
+        source $LANGFILE
+        echo "Geyser Player-connected-message. Sending webhook..."
+        webhook_compact "$MESSAGE" 3447003 "https://minotar.net/helm/$PLAYER?v=$CACHE"
+        ;;
+
+    # Other Geyser server messages
+    *\/INFO\]*)
+        MESSAGE=$(echo "$LINE" | cut -d "]" -f 2 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+        source $LANGFILE
+        echo "Geyser INFO-message #2. Sending webhook..."
+        webhook_compact "$MESSAGE" 3447003 "https://geysermc.org/img/icons/geyser.png"
+        ;;
+
+    # Other Geyser server messages
+    *\/WARN\]*)
+        MESSAGE=$(echo "$LINE" | cut -d "]" -f 2 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+        source $LANGFILE
+        echo "Geyser WARN-message #2. Sending webhook..."
+        webhook_compact "$MESSAGE" 10366780 "https://geysermc.org/img/icons/geyser.png"
         ;;
 
     esac

--- a/minecraft-discord-webhook.sh
+++ b/minecraft-discord-webhook.sh
@@ -48,6 +48,7 @@ function webhook_compact() {
         -d '{
                 "username": "Minecraft",
                 "avatar_url" : "https://www.minecraft.net/etc.clientlibs/minecraft/clientlibs/main/resources/android-icon-192x192.png",
+                "content": "'"$1"'",
                 "embeds": [{
                     "color": "'"$2"'",
                     "author": {

--- a/minecraft-discord-webhook.sh
+++ b/minecraft-discord-webhook.sh
@@ -43,7 +43,7 @@ echo "================================================="
 
 # compact version of the webhook
 function webhook_compact() {
-    curl --no-progress-meter -H "Content-Type: application/json" \
+    curl -H "Content-Type: application/json" \
         -X POST \
         -d '{
                 "username": "Minecraft",

--- a/minecraft-discord-webhook.sh
+++ b/minecraft-discord-webhook.sh
@@ -61,6 +61,9 @@ function webhook_compact() {
             }' $WEBHOOK_URL
 }
 
+# send a message that the service has started
+webhook_compact "$0 started monitoring $SERVERLOG/latest.log" 9737364 "https://www.minecraft.net/etc.clientlibs/minecraft/clientlibs/main/resources/android-icon-192x192.png"
+
 # actual loop with parsing of the log
 tail -n 0 -F $SERVERLOG/latest.log | while read LINE; do
     case $LINE in
@@ -144,7 +147,7 @@ tail -n 0 -F $SERVERLOG/latest.log | while read LINE; do
         ;;
 
     # Geyser client proxied 
-    *has\ connected\ to\ remote* | has\ disconnected\ from\ remote )
+    *has\ connected\ to\ remote* | *has\ disconnected\ from\ remote* )
         MESSAGE=$(echo "$LINE" | cut -d "]" -f 2 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
         PLAYER=$(echo "$MESSAGE" | cut -d " " -f 1)
         source $LANGFILE

--- a/minecraft-discord-webhook.sh
+++ b/minecraft-discord-webhook.sh
@@ -51,12 +51,16 @@ echo "================================================="
 
 # compact version of the webhook
 function webhook_compact() {
+    CONTENT=""
+    if [ "$PREVIEW" ]; then
+        CONTENT=$1
+    fi
     curl -H "Content-Type: application/json" \
         -X POST \
         -d '{
                 "username": "'"$BOTNAME"'",
                 "avatar_url" : "'"$AVATAR"'",
-                "content": "'"$1"'",
+                "content": "'"$CONTENT"'",
                 "embeds": [{
                     "color": "'"$2"'",
                     "author": {

--- a/minecraft-discord-webhook.sh
+++ b/minecraft-discord-webhook.sh
@@ -32,6 +32,14 @@ if [ -z "$LANGUAGE" ]; then
     LANGUAGE="en-US"
 fi
 
+if [ -z "$BOTNAME" ]; then
+    BOTNAME="Minecraft"
+fi
+if [ -z "$AVATAR" ]; then
+    AVATAR="https://www.minecraft.net/etc.clientlibs/minecraft/clientlibs/main/resources/android-icon-192x192.png"
+fi
+
+
 LANGFILE=$DIR/lang/$LANGUAGE.sh
 echo "================================================="
 echo "Starting webhooks script with the following info:"
@@ -46,8 +54,8 @@ function webhook_compact() {
     curl -H "Content-Type: application/json" \
         -X POST \
         -d '{
-                "username": "Minecraft",
-                "avatar_url" : "https://www.minecraft.net/etc.clientlibs/minecraft/clientlibs/main/resources/android-icon-192x192.png",
+                "username": "'"$BOTNAME"'",
+                "avatar_url" : "'"$AVATAR"'",
                 "content": "'"$1"'",
                 "embeds": [{
                     "color": "'"$2"'",


### PR DESCRIPTION
Adding a few lines to also parse GeyserMC logs.
It is nice to have both the server logs and the GeyserMC-logs in the same channel, using the same script, and yours made perfectly sense.

I also included a few more optional environment variables so the bot name and avatar can be changed easily,

- Discovered that the default avatar url does not seem to work.  At least here.  It might be blocked by Microsoft somehow, because the URL opens fine in a browser.  But no Icon is shown in Discord.