### PR TITLE
Stop villager deaths from being sent to the webhook

### DIFF
--- a/minecraft-discord-webhook.sh
+++ b/minecraft-discord-webhook.sh
@@ -84,6 +84,9 @@ tail -n 0 -F $SERVERLOG/latest.log | while read LINE; do
     # match for chat message. If it's chat, we catch it first so we don't trigger false positives later
     *\<*\>*) echo "Chat message" ;;
 
+    # Consume any line that mentions a Villager so that we dont push their death through the webhook
+    *EntityVillager* ) echo "Skipping Villager death" ;;
+
     # joins and parts
     *joined\ the\ game)
         PLAYER=$(echo "$LINE" | grep -o ": .*" | awk '{print $2}')


### PR DESCRIPTION
> [01:40:25 INFO]: Villager EntityVillager['Villager'/55659, uuid='70f5ed3f-fd6c-6e4e-97a7-3b58784d53bf', l='ServerLevel[World]', x=-3020.50, y=62.47, z=-3188.70, cpos=[-189, -200], tl=2693642, v=true] died, message: 'Villager tried to swim in lava'

^ Log message from PaperMC that spammed my discord server. 